### PR TITLE
Add support for ACF 5.10.x

### DIFF
--- a/src/ACFProInstaller/Plugin.php
+++ b/src/ACFProInstaller/Plugin.php
@@ -184,7 +184,7 @@ class Plugin implements PluginInterface, EventSubscriberInterface
     {
         // \A = start of string, \Z = end of string
         // See: http://stackoverflow.com/a/34994075
-        $major_minor_patch_optional = '/\A\d\.\d\.\d{1,2}(?:\.\d)?(?:\-(dev|beta|RC)?(\d{1,2})?)?\Z/';
+        $major_minor_patch_optional = '/\A\d\.\d{1,2}\.\d{1,2}(?:\.\d)?(?:\-(dev|beta|RC)?(\d{1,2})?)?\Z/';
 
         if (!preg_match($major_minor_patch_optional, $version)) {
             throw new \UnexpectedValueException(

--- a/tests/ACFProInstaller/PluginTest.php
+++ b/tests/ACFProInstaller/PluginTest.php
@@ -379,6 +379,11 @@ class PluginTest extends \PHPUnit_Framework_TestCase
         $this->versionPassesValidationHelper('1.2.3.4');
     }
 
+    public function testExactVersionWithMinorDoubleDigitsPassesValidation()
+    {
+        $this->versionPassesValidationHelper('1.20.3');
+    }
+
     public function testExactVersionWithPatchDoubleDigitsPassesValidation()
     {
         $this->versionPassesValidationHelper('1.2.30');


### PR DESCRIPTION
A follow-up to [version 1.0.2](https://github.com/schliflo/acf-pro-installer/releases/tag/v1.0.2), released in 2016:

> This might have to change if 5.10.*.* or 10.*.*.* approaches.